### PR TITLE
src/clyso/ceph/ai/osd: minor fixes to get correct result for perf dump

### DIFF
--- a/otto/src/clyso/ceph/ai/osd/command.py
+++ b/otto/src/clyso/ceph/ai/osd/command.py
@@ -50,9 +50,20 @@ class OSDPerfCommand:
         try:
             if self.args.osd_id:
                 print(f"Analyzing OSD {self.args.osd_id}...")
+                try:
+                    topology = OSDTopology()
+                    osd_metadata = topology.osd_metadata.get(self.args.osd_id, {})
+                except Exception as e:
+                    print(f"Warning: Could not get topology info: {e}")
+                    osd_metadata = {}
                 self.osd_metrics = self.perf_class.collect_single_osd_metrics(
                     self.args.osd_id, skip_confirmation=skip_confirmation
                 )
+                # Apply metadata to the metrics for single OSD
+                for metric in self.osd_metrics:
+                    metric.osd_id = self.args.osd_id
+                    metric.host = osd_metadata.get("hostname", "unknown")
+                    metric.device_class = osd_metadata.get("device_class", "unknown")
                 self.failed_osds = []
 
             elif self.args.file:

--- a/otto/src/clyso/ceph/ai/osd/topology.py
+++ b/otto/src/clyso/ceph/ai/osd/topology.py
@@ -55,7 +55,7 @@ class OSDTopology:
                     device_class_to_osds[device_class].append(osd_id)
 
                     osd_metadata[osd_id] = {
-                        "host": host_name,
+                        "hostname": host_name,
                         "device_class": device_class,
                     }
 

--- a/otto/src/clyso/ceph/api/schemas.py
+++ b/otto/src/clyso/ceph/api/schemas.py
@@ -1257,7 +1257,7 @@ class OSDPerfDumpResponse(BaseModel):
 
     objecter: ObjecterMetrics = Field(default_factory=ObjecterMetrics)
     osd: OSDMetrics = Field(default_factory=OSDMetrics)
-    osd_slow_ops: OSDSlowOps = Field(alias="osd-slow-ops")
+    osd_slow_ops: Optional[OSDSlowOps] = Field(alias="trackedop")
 
     recoverystate_perf: RecoveryStatePerf = Field(default_factory=RecoveryStatePerf)
 


### PR DESCRIPTION
`
"trackedop": {
        "slow_ops_count": 0
    }
    `
    
Changed the alias here because the field shows up as "trackedop". Also, made it optional in case to prevent other issues. Also, there is an additional fix so that osd perf for specified osd collects osd metadata and shows it in the output. Before, it was only collecting metadata for the perf dump of the whole cluster. So the device, class and osd fields in output of perf dump for a specified osd id would show up as unknown. It has been fixed now