### PR TITLE
otto: update report crush_location field to support newer Ceph

### DIFF
--- a/otto/src/clyso/ceph/api/schemas.py
+++ b/otto/src/clyso/ceph/api/schemas.py
@@ -1772,7 +1772,7 @@ class MonInfo(CephBaseModel):
     addr: str = Field(default="")
     priority: int = Field(default=0)
     weight: int = Field(default=0)
-    crush_location: str = Field(default="")
+    crush_location: str | list[Any] = Field(default_factory=list)
 
 
 class MonMap(CephBaseModel):


### PR DESCRIPTION
Fixes: https://github.com/clyso/otto/issues/70