### PR TITLE
Updating content as per yesterday's Ceph Weekly

### DIFF
--- a/otto/src/clyso/ceph/ai/report.py
+++ b/otto/src/clyso/ceph/ai/report.py
@@ -69,7 +69,7 @@ def check_report_version(result: AIResult, data: CephData) -> None:
         return _handle_very_old_version(result, ver, recommended_versions())
 
     if release_info.get("version") == ver and release_info.get("recommended", False):
-        return _handle_recommended_version(result, ver)
+        return _handle_recommended_version(result, ver, release_info.get("caveats"))
 
     return _handle_non_recommended_version(
         result, ver, recommended_versions(), release_info.get("version")
@@ -86,7 +86,21 @@ def _handle_very_old_version(result, ver, rec_versions) -> None:
     result.add_check_result("Version", "Release", "FAIL", summary, detail, recommend)
 
 
-def _handle_recommended_version(result, ver) -> None:
+def _handle_recommended_version(result, ver, caveats=None) -> None:
+    if caveats:
+        summary = f"Running recommended stable release {ver}, but with caveats"
+        detail = [
+            f"Cluster is running {ver}. This is one of the recommended stable releases, however the following caveats apply:"
+        ]
+        recommend = []
+        for caveat in caveats:
+            detail.append(f"- {caveat}")
+            recommend.append(caveat)
+        result.add_check_result(
+            "Version", "Release", "WARN", summary, detail, recommend
+        )
+        return
+
     summary = f"Running a recommended stable release {ver}"
     detail = [
         f"Cluster is running {ver}. This is one of the recommended stable releases."

--- a/otto/src/clyso/ceph/ai/versions.yaml
+++ b/otto/src/clyso/ceph/ai/versions.yaml
@@ -1,9 +1,8 @@
 ---
 
-# versions: x.y.z are supportable ceph version clyso recommends
-# a version is marked old if there is no 'version' key
-# recommended: is default to false, put true if the version is recommended
-# IMPORTANT: Don't forget to update the Customer Support Portal FAQ article at: https://support.clyso.com/otrs/index.pl?Action=AgentFAQZoom;ItemID=35
+# A Ceph release is flagged as 'old' if the 'version' key is missing.
+# The 'recommended' key defaults to false; it is set to true only if Clyso recommends this version for production environments.
+# IMPORTANT: If you modify this, please update the corresponding Customer Support Portal FAQ article at: https://support.clyso.com/otrs/index.pl?Action=AgentFAQZoom;ItemID=35
 
 releases:
   v9:
@@ -28,19 +27,21 @@ releases:
   v17:
     name: quincy
     version: 17.2.7
-    recommended: true
   v18:
     name: reef
-    version: 18.2.7
+    version: 18.2.8
     recommended: true
   v19:
     name: squid
     version: 19.2.3
+    recommended: true
+    caveats:
+        - See https://docs.clyso.com/docs/kb/known-bugs/squid/#squid-deployed-osds-are-crashing    
   v20:
     name: tentacle
-    version: 20.2.0
+    version: 20.2.1
   v21:
-    name: u
+    name: umbrella
   v22:
     name: v
   v23:

--- a/tests/otto.json
+++ b/tests/otto.json
@@ -50,11 +50,11 @@
           "result": "WARN",
           "summary": "Not running a recommended stable release",
           "detail": [
-            "Cluster is running 16.2.9. Clyso highly recommends one of the stable releases: 17.2.7, 18.2.7.",
+            "Cluster is running 16.2.9. Clyso highly recommends one of the stable releases: 18.2.8, 19.2.3.",
             "16.2.15 is the recommended bugfix release for your current version."
           ],
           "recommend": [
-            "Upgrade to one of the stable releases: 17.2.7, 18.2.7.",
+            "Upgrade to one of the stable releases: 18.2.8, 19.2.3.",
             "Alternatively, upgrade to 16.2.15."
           ]
         },


### PR DESCRIPTION
- Removing recommendation to use Quincy (doesn't mean we stop supporting it)
- Bumping Reef to 18.2.8
- Adding recommendation to use Squid starting from 19.2.3 with additional caveats key.
- Bumping Tentacle to 20.2.1
- Adding full name for Umbrella