### PR TITLE
ceph/otto: add --format json to checkup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Overall score: 28 out of 35 (F)
 Use --verbose or --summary for details and recommendations
 ```
 
+### Machine-readable output
+
+For cron, CI, or monitoring, emit the full result document as JSON:
+
+```bash
+otto cluster checkup --ceph_report_json=report.json --format json
+```
+
+`--format json` writes the complete result to stdout (warnings go to stderr, so
+stdout stays valid JSON). The document has the shape
+`{"summary": {...}, "sections": [...]}`.
+
 ## Requirements
 
 - Python 3.11+

--- a/otto/src/clyso/ceph/otto/__init__.py
+++ b/otto/src/clyso/ceph/otto/__init__.py
@@ -222,12 +222,15 @@ def subcommand_checkup(args: argparse.Namespace) -> None:
         warnings.append("Config dump analysis skipped - using static report")
 
     if args.verbose or args.summary:
+        warning_stream = sys.stderr if args.format == "json" else None
         for warning in warnings:
-            print(f"Warning: {warning}")
+            print(f"Warning: {warning}", file=warning_stream)
 
     result = generate_result(ceph_data=data)
 
-    if args.summary:
+    if args.format == "json":
+        print(result.dump())
+    elif args.summary:
         compact_result_summary(result.dump())
     elif args.verbose:
         verbose_result(result.dump())
@@ -521,6 +524,13 @@ def main():
     )
     parser_checkup.add_argument("--summary", action="store_true", help="Summary output")
     parser_checkup.add_argument("--verbose", action="store_true", help="Verbose output")
+    parser_checkup.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format: 'text' (default, honors --summary/--verbose) "
+        "or 'json' (machine-readable, full result document)",
+    )
     parser_checkup.set_defaults(func=subcommand_checkup)
 
     # TODO: add back once we start collecting for this

--- a/tests/test_checkup_output.py
+++ b/tests/test_checkup_output.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2025 Clyso
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+FIXTURE = str(Path(__file__).parent / "report.pacific.json")
+
+
+def _run(*extra_args):
+    return subprocess.run(  # noqa: S603
+        ["otto", "checkup", "-i", FIXTURE, *extra_args],  # noqa: S607
+        capture_output=True,
+        text=True,
+    )
+
+
+class CheckupOutputTest(unittest.TestCase):
+    def test_format_json_shape(self):
+        proc = _run("--format", "json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        doc = json.loads(proc.stdout)
+        self.assertEqual(set(doc.keys()), {"summary", "sections"})
+        self.assertLessEqual(
+            {"score", "grade", "max_score"}, set(doc["summary"].keys())
+        )
+
+    def test_text_flags_do_not_leak_into_json(self):
+        plain = _run("--format", "json")
+        with_verbose = _run("--format", "json", "--verbose")
+        self.assertEqual(plain.returncode, 0, plain.stderr)
+        self.assertEqual(with_verbose.returncode, 0, with_verbose.stderr)
+        self.assertEqual(plain.stdout, with_verbose.stdout)
+
+    def test_default_behavior_unchanged(self):
+        proc = _run()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(
+            proc.stdout.startswith("Running tests:"),
+            f"Unexpected default output: {proc.stdout!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
adds json output to checkup. warnings are redirected to stderr in JSON mode so stdout stays valid JSON.