### PR TITLE
fixes to checkup command on versioning

### DIFF
--- a/otto/src/clyso/ceph/ai/helpers.py
+++ b/otto/src/clyso/ceph/ai/helpers.py
@@ -27,9 +27,10 @@ def to_major(version: str) -> str:
     return "v" + x
 
 
-def to_release(version: str) -> str:
+def to_release(version: str) -> str | None:
     major = to_major(version)
-    return versiondb["releases"][major].get("name")
+    release = versiondb["releases"].get(major)
+    return release.get("name") if release else None
 
 
 def recommended_versions():

--- a/otto/src/clyso/ceph/ai/report.py
+++ b/otto/src/clyso/ceph/ai/report.py
@@ -65,7 +65,9 @@ def check_report_version(result: AIResult, data: CephData) -> None:
     major = to_major(ver)
     release_info = versiondb["releases"].get(major, {})
 
-    if release_info.get("version", "old") == "old":
+    if "version" not in release_info:
+        if _is_newer_than_curated(major):
+            return _handle_newer_than_curated(result, ver, recommended_versions())
         return _handle_very_old_version(result, ver, recommended_versions())
 
     if release_info.get("version") == ver and release_info.get("recommended", False):
@@ -74,6 +76,35 @@ def check_report_version(result: AIResult, data: CephData) -> None:
     return _handle_non_recommended_version(
         result, ver, recommended_versions(), release_info.get("version")
     )
+
+
+def _max_curated_major() -> int:
+    """Highest major (e.g. 20 for v20) that has a curated stable version."""
+    majors = [
+        int(major.lstrip("v"))
+        for major, info in versiondb["releases"].items()
+        if "version" in info
+    ]
+    return max(majors) if majors else 0
+
+
+def _is_newer_than_curated(major: str) -> bool:
+    """True if `major` (e.g. 'v21') is newer than any curated release."""
+    return int(major.lstrip("v")) > _max_curated_major()
+
+
+def _handle_newer_than_curated(result, ver, rec_versions) -> None:
+    summary = f"Running {ver}, newer than our recommended versions"
+    detail = [
+        f"Cluster is running {ver}, which is newer than the most recent release "
+        f"Clyso has reviewed. Clyso currently recommends one of the stable "
+        f"releases: {', '.join(rec_versions)}."
+    ]
+    recommend = [
+        "Confirm this release is suitable for production; it has not yet been "
+        "reviewed by Clyso."
+    ]
+    result.add_check_result("Version", "Release", "WARN", summary, detail, recommend)
 
 
 def _handle_very_old_version(result, ver, rec_versions) -> None:
@@ -432,7 +463,15 @@ def check_report_osdmap(result: AIResult, data: CephData) -> None:
     major = to_major(report.version)
     r_o_r = osdmap.require_osd_release
     running_release = to_release(major)
-    if r_o_r != running_release:
+    if not running_release or len(running_release) <= 1:
+        # in the event versions.yaml carries no real release name for this major yet
+        summary = "Unable to verify require_osd_release"
+        detail = [
+            f"require_osd_release is set to {r_o_r!r}, but Clyso does not have a "
+            f"release name on file for {major} to compare against."
+        ]
+        result.add_check_result(section, check, "WARN", summary, detail, recommend)
+    elif r_o_r.strip().lower() != running_release.strip().lower():
         summary = "CRITICAL: require_osd_release is incorrect!"
         detail = [
             f"require_osd_release {r_o_r} does not match running release {running_release}"

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -229,6 +229,63 @@ class TestClysoCephAI(unittest.TestCase):
                     current_version,
                 )
 
+    def test_newer_than_curated_release_is_not_flagged_old(self) -> None:
+        # A release newer than anything curated in versions.yaml (e.g. a freshly
+        # shipped Ceph release) must NOT be reported as "very old". It should
+        # WARN, not force a critical FAIL. Regression test for tentacle/future
+        # releases being mislabeled "CRITICAL: Running very old release".
+        test_path = Path(__file__).parent
+        report_json = json.loads((test_path / "report-reef.json").read_text())
+
+        for newer_version in ["21.0.0", "26.9.9"]:
+            with self.subTest(version=newer_version):
+                report_json["version"] = newer_version
+                data = CephData()
+                data.ceph_report = CephReport.model_validate(report_json)
+                result = ai_module.generate_result(ceph_data=data)
+                result_json = json.loads(result.dump())
+
+                version_section = next(
+                    s for s in result_json["sections"] if s["id"] == "Version"
+                )
+                release_check = next(
+                    c for c in version_section["checks"] if c["id"] == "Release"
+                )
+
+                assert release_check["result"] == "WARN", (
+                    f"{newer_version} should WARN, not "
+                    f"{release_check['result']}: {release_check['summary']}"
+                )
+                assert "very old" not in release_check["summary"].lower(), (
+                    f"{newer_version} must not be labeled 'very old': "
+                    f"{release_check['summary']}"
+                )
+
+    def test_require_osd_release_not_flagged_for_unknown_name(self) -> None:
+        test_path = Path(__file__).parent
+        report_json = json.loads((test_path / "report-reef.json").read_text())
+        report_json["version"] = "24.1.0"  # v24 -> placeholder name "x"
+        report_json["osdmap"]["require_osd_release"] = "wombat"
+
+        data = CephData()
+        data.ceph_report = CephReport.model_validate(report_json)
+        result_json = json.loads(ai_module.generate_result(ceph_data=data).dump())
+
+        osd_check = next(
+            c
+            for section in result_json["sections"]
+            for c in section.get("checks", [])
+            if c["id"] == "Check require_osd_release flag"
+        )
+        assert osd_check["result"] == "WARN", (
+            f"placeholder release name should WARN, not {osd_check['result']}: "
+            f"{osd_check['summary']}"
+        )
+        assert "CRITICAL" not in osd_check["summary"], osd_check["summary"]
+        assert not any("require-osd-release x" in r for r in osd_check["recommend"]), (
+            f"must not recommend a placeholder name: {osd_check['recommend']}"
+        )
+
     def _check_version_release(
         self,
         test_path,


### PR DESCRIPTION
Example on a v20.2.1 cluster. Fixes to detect newer versions and outputting correct 'require_osd_release' warning

example of warnings that shouldn't be
```
Summary CRITICAL: Running very old release 20.2.1

Summary: CRITICAL: require_osd_release is incorrect!
Details:
  - require_osd_release tentacle does not match running release t

```