### PR TITLE
report: mon quorum math change to floor(mons/2 + 1)

### DIFF
--- a/otto/src/clyso/ceph/ai/report.py
+++ b/otto/src/clyso/ceph/ai/report.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import sys
 import traceback
-from math import ceil, fsum, log2
+from math import ceil, fsum, log2, floor
 
 import humanize
 from packaging import version
@@ -359,7 +359,7 @@ def check_even_num_mons(result: AIResult, data: CephData) -> None:
     if num_mons % 2 == 0:
         summary = "Even number of Monitors"
         detail = [
-            f"Cluster has an even number of ceph-mon daemons ({num_mons}). This is not a problem however operators should be aware that the {ceil(num_mons / 2 + 1)} of the monitors must be up to maintain quorum."
+            f"Cluster has an even number of ceph-mon daemons ({num_mons}). This is not a problem however operators should be aware that the {floor(num_mons / 2 + 1)} of the monitors must be up to maintain quorum."
         ]
         recommend = ["Run an odd number of ceph-mon daemons"]
         passfail = "WARN"
@@ -367,7 +367,7 @@ def check_even_num_mons(result: AIResult, data: CephData) -> None:
     else:
         summary = "Odd number of Monitors"
         detail = [
-            f"Cluster has an odd number of ceph-mon daemons ({num_mons}). This is ideal for the underlying Monitor PAXOS quorum algorithm. Quorum will be maintained as long as {ceil(num_mons / 2 + 1)} ceph-mon daemons are up and healthy."
+            f"Cluster has an odd number of ceph-mon daemons ({num_mons}). This is ideal for the underlying Monitor PAXOS quorum algorithm. Quorum will be maintained as long as {floor(num_mons / 2 + 1)} ceph-mon daemons are up and healthy."
         ]
         recommend = []
         passfail = "PASS"


### PR DESCRIPTION
math for keeping mon quorum based on number of mons

7 mons : floor(7/2 +1) = 4
5 mons : floor(5/2 +1) = 3
3 mons : floor(3/2 +1) = 2

shouldn't affect even number mons 
4 mons : floor(4/2 +1) = 3
